### PR TITLE
Add .mp4 as viable file type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/html/nbproject/private/
+*.txt

--- a/html/index.php
+++ b/html/index.php
@@ -12,7 +12,7 @@
 <?php
 // Path
 $dir = "/home/pi/songs/";
-$files = glob($dir . '*.mp3');
+$files = glob($dir . '*.{mp3,mp4}', GLOB_BRACE);
 $ar = null; ?>
 
 <div data-role="page" id="home">

--- a/html/index.php
+++ b/html/index.php
@@ -91,7 +91,7 @@ $ar = null; ?>
                     $ar = $artist;
                 }
 
-                echo '<li data-filtertext="' . $artist . ':' . $song . '" ><a href="#trackDialog" data-artist-title="' . $filename . '" onclick="selectTrack(\'' . $file . '\');" data-rel="dialog" data-transition="pop">' . $song . '</a></li>';
+                echo '<li data-filtertext="' . $artist . ':' . $song . '" ><a href="#trackDialog" data-artist-title="' . $filename . '" onclick="selectTrack(\'' . str_replace("'","\'",$file) . '\');" data-rel="dialog" data-transition="pop">' . $song . '</a></li>';
             }
             ?></ul>
     </div>


### PR DESCRIPTION
I found that finding .mp3/.cdg files online was relatively difficult. However lyric videos in .mp4 format are very common. This fix is allowing me to rapidly grow my karaoke collection, so I wanted to share the update if you’re interested.